### PR TITLE
Scope and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,48 @@
-# Proposed Apperta Repository Management
-Proposal for a policy for management of non-Apperta repositories which respects autonomy of project originators while strongly protecting Apperta's community investment. 
+# Apperta guide to working in the open
 
-### Request For Comment
+Apperta believes that [making things open makes them better](https://web.archive.org/web/20140628221103/https://www.gov.uk/design-principles#ninth).
 
-* Movement of a GitHub repository involves considerable work, none of which improves the quality of the code, the features of the project, and much of which can actually cause harm to the project.
+All Apperta supported projects are encouraged to work in the open and share what they're doing whenever they can.
 
-### THEREFORE:
+### Request for comment
+
+This document is a **proposal**, and Apperta actively seeks feedback on it via Github Issues and Pull Requests to this repository.
+
+## Code management
+
+Apperta supports many open source projects which it does not itself maintain. 
+
+This document outlines the expectations Apperta has of such projects, and how Apperta will behave with respect to those projects.
+
+The goal of this policy is to respect the autonomy and independence of project originators as much as possible while strongly protecting Apperta's community investment.
+
+In the common case, movement of a GitHub repository involves considerable work, none of which improves the quality of the code, the features of the project, and much of which can actually cause harm to the project.
+
+Furthermore Apperta is in general unlikely to be the sole investor in most open source projects it supports over their lifetime. This would in fact be unsustainable and a risk to the projects and the broader ecosystem. Therefore Apperta **EXPECTS** source code to be managed by whichever person or institution is the maintainer of the proejct.
+ 
+### Responsibilities of maintainers
 
 1. Repositories **SHOULD** remain in the GitHub Organisation of the originator, **UNLESS** the Apperta Technical Subcomittee deem that there is a significant risk of loss of the community's asset through a future closure of the source code, in which case the Apperta Foundation will fork the repository to the Apperta Foundation GitHub organisation.
 
-1. Originators **SHOULD** have demonstrably open source code using a public source code management tool (such as GitHub) 
+1. Projects **SHOULD** have demonstrably open source code using a public source code management tool (such as GitHub) 
 
 1. Source code **SHOULD** be up to date with the latest development tip. 
 
-1. Originators **SHOULD** demonstrate a willingness to accept contributions from the community such as Issues and Pull Requests.
+1. Projects **SHOULD** demonstrate a willingness to accept contributions from the community such as Issues and Pull Requests.
 
 1. Live, public internet-facing demonstration instances of the supported apps **SHOULD** be maintained by the originators, under subdomains of the apperta.org top level domain if appropriate.
+
+1. Projects **SHOULD** display the ['Supported By Apperta' badge](https://github.com/AppertaFoundation/apperta-image-assets/blob/master/supported_by_apperta_lores.png) on the repositories which have been supported by Apperta, and may demonstrate attribution in other ways if they so wish.
+
+1. Repositories **SHOULD** have a clear copyright notice* stating the copyright owner, and an equally clear [OSI-approved open source license](https://opensource.org/licenses).
+
+### Responsibilities of Apperta
 
 1. Apperta **WILL** maintain a simple list or directory of such supported apps and components; their respective subdomain URLs; and appropriate documentation so as to make a demonstration interaction possible.
 
 1. Apperta **MAY** download code snapshots from the originators' repository at the point of completion of a project or at any other time, in order to protect their investment in development of projects.
 
 1. Apperta **MAY** fork a code repository from the originators' repository at the point of completion of a project or at any other time, in order to protect their investment in development of projects.
-
-1. Originators **SHOULD** display the ['Supported By Apperta' badge](https://github.com/AppertaFoundation/apperta-image-assets/blob/master/supported_by_apperta_lores.png) on the repositories which have been supported by Apperta, and may demonstrate attribution in other ways if they so wish.
-
-1. All Apperta-supported projects **SHOULD** have a clear copyright notice* stating the copyright owner, and an equally clear [OSI-approved open source license](https://opensource.org/licenses).
 
 1. In exceptional circumstances, variations to this policy may be discussed and agreed by the Apperta Board, for individual projects.
 


### PR DESCRIPTION
Broaden the headline scope, and update the framing somewhat.

Change the language to make this a policy document intended for publication rather than a proposal intended for internal circulation and discussion.

Change the structure to separate the expectations of maintainers/originators from what they can expect of Apperta.